### PR TITLE
ci: update GitHub Actions workflow to use pnpm setup action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -25,8 +26,10 @@ jobs:
           node-version: 20
           cache: "pnpm"
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
       - name: Install dependencies with pnpm
         run: pnpm install


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to improve dependency management and streamline the setup process. The most important changes include replacing the manual installation of `pnpm` with the official `pnpm/action-setup` action and adding a missing newline for better formatting.

### Workflow improvements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L28-R32): Replaced the manual installation of `pnpm` (`npm install -g pnpm`) with the `pnpm/action-setup@v2` GitHub Action, specifying version 8 for better maintainability and consistency.

### Formatting adjustments:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R18): Added a newline after `runs-on: ubuntu-latest` in the `deploy` job for improved readability.